### PR TITLE
Change chainId if backend gives native token

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -102,7 +102,6 @@ class App extends Component {
         }});
       this.setState({keplrLoaded: false});
     } else {
-      console.log()
       // Thank you jhernandez for the tip
       window.keplr.defaultOptions = {
         sign: {


### PR DESCRIPTION
With this PR:
https://github.com/starryzone/starrybot-discord/pull/71

We add the ability to send the frontend info about the latest native token address the Discord guild has added to their token rules. What this means is the frontend can then adjust which chain it's pointing to.

Currently when someone signs with Keplr, it's hardcoded to use the Cosmos Hub. But as you know from fiddling with Keplr, there are many chains in the dropdown.

Some folks from Stargaze reached out to me to mention that if it's always using the Cosmos Hub, AND Keplr doesn't allow attaching zero gas for offline signing, then it requires the end user to have ATOM on their account, even though they may only be focused on having STARS.

Hence, if we can tell Keplr which chain id to connect to, we can solve some UX issues brought up.