### PR TITLE
Update download button with reduced permissions

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -270,7 +270,7 @@ class App extends Component {
             <div id="add-bot" className="column large-7">
               <div className={"add-bot-button large button round-button"}>
                 <a
-                  href="https://discord.com/oauth2/authorize?client_id=912554498050891796&scope=applications.commands%20bot&permissions=8">Add
+                  href="https://discord.com/oauth2/authorize?client_id=912554498050891796&scope=applications.commands%20bot&permissions=268486720">Add
                   Bot
                   <img src={star.default} alt="yellow star"/>
                 </a>


### PR DESCRIPTION
    As part of removing the need for Privileged Gateway Intents in
    starrybot, we figured out exactly what minimal permissions were
    necessary for the bot to run. This commit updates the installation
    URL so this is now the recommended configuration.

Note - this can **not** be merged until https://github.com/starryzone/starrybot-discord/pull/115 is working in Production, as the current bot still relies on the message-related permissions/gateway intents for the 'input' prompts.